### PR TITLE
async updates to support pydle 0.8.5+

### DIFF
--- a/irc.py
+++ b/irc.py
@@ -4,7 +4,7 @@
 #
 from halibot import HalAgent, HalConfigurer, Message
 from collections import OrderedDict
-import pydle, threading
+import pydle, threading, asyncio
 
 # Haliot Reference IRC Agent
 #  Creates a Pydle IRC Client and connects to a server
@@ -61,7 +61,7 @@ class IrcAgent(HalAgent):
 	#  using the whom as the "channel", which is the tail end of the resource
 	#  identifier for this target (e.g. the "#foo" in "irc/#foo").
 	def receive(self, msg):
-		self.client.message(msg.whom(), msg.body)
+		asyncio.ensure_future(self.client.message(msg.whom(), msg.body), loop=self.eventloop)
 
 	def shutdown(self):
 		self.client.disconnect()
@@ -106,7 +106,7 @@ class IrcClient(pydle.Client):
 	#  NOTE: the config field is automatically populated from the relevant
 	#   config files when the module is loaded
 	async def on_connect(self):
-		super().on_connect()
+		await super().on_connect()
 
 		channel = self.agent.config['channel']
 		if isinstance(channel, str):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-pydle
+pydle>=0.8.5


### PR DESCRIPTION
Fixes #3.

I know there is the question of what to do about people with out of date pydle versions. This update mandates that people use pydle>=0.8.5. I think that the solution to what to do about people on older pydle versions that doesn't require them to update is to add versioning support to the halibot package manager (which is something that has been a long time coming anyway) and integrate `requirements.txt` with `halibot add`.

For now, I think this should just be merged so that this agent is working again.